### PR TITLE
Fake SQS: make sure supervisor is installed first

### DIFF
--- a/recipes/fake-sqs.rb
+++ b/recipes/fake-sqs.rb
@@ -1,3 +1,5 @@
+include_recipe "raven-supervisor"
+
 package "rubygem-rack" do
 	version "1.6.4-1"
 end


### PR DESCRIPTION
This includes `raven-supervisor::default` explicitly to ensure it is installed before attempting to install a supervisor-managed program.
